### PR TITLE
fix(Local Run & Local Debug): fix local run & local debug event file path with white blank

### DIFF
--- a/src/commands/importFunction.ts
+++ b/src/commands/importFunction.ts
@@ -36,7 +36,9 @@ async function process(serviceName: string, functionName: string) {
     }
   }
   const { importFunction } = require('@alicloud/fun/lib/import/function.js');
-  await importFunction(serviceName, functionName, cwd).catch((ex: any) => { output.error(ex.message) });
+  await output.output(() =>
+    importFunction(serviceName, functionName, cwd).catch((ex: any) => { output.error(ex.message) })
+  );
   vscode.commands.executeCommand(serverlessCommands.REFRESH_LOCAL_RESOURCE.id);
 }
 

--- a/src/commands/importService.ts
+++ b/src/commands/importService.ts
@@ -38,7 +38,9 @@ async function process(serviceName: string) {
     }
   }
   const { importService } = require('@alicloud/fun/lib/import/service.js');
-  await importService(serviceName, cwd).catch((ex: any) => { output.error(ex.message) });
+  await output.output(() =>
+    importService(serviceName, cwd).catch((ex: any) => { output.error(ex.message) })
+  );
   vscode.commands.executeCommand(serverlessCommands.REFRESH_LOCAL_RESOURCE.id);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import * as output from './utils/output';
 import { serverlessCommands } from './utils/constants';
 import { recordPageView } from './utils/visitor';
 import { initProject } from './commands/initProject';
@@ -64,9 +63,6 @@ export function activate(context: vscode.ExtensionContext) {
   clearRemoteServiceInfo(context);
   importService(context);
   importFunction(context);
-
-  console.log = output.log;
-  console.error = output.error;
 
   vscode.commands.executeCommand(serverlessCommands.SHOW_REGION_STATUS.id);
   vscode.languages.registerCodeLensProvider(['javascript', 'python', 'php'], new ServerlessLensProvider(cwd));

--- a/src/services/FunService.ts
+++ b/src/services/FunService.ts
@@ -26,7 +26,7 @@ export class FunService {
 
   localInvoke(serviceName: string, functionName: string, eventFilePath: string) {
     const terminal =  terminalService.getFunctionComputeTerminal();
-    const command = `fun local invoke ${serviceName}/${functionName} -e ${eventFilePath}`
+    const command = `fun local invoke ${serviceName}/${functionName} -e ${eventFilePath.replace(/ /g, '\\ ')}`
     terminal.sendText(command);
     terminal.show();
   }
@@ -34,7 +34,8 @@ export class FunService {
   localInvokeDebug(serviceName: string, functionName: string,
     debugPort: string, eventFilePath: string): vscode.Terminal {
     const terminal =  terminalService.getFunctionComputeTerminal();
-    const command = `fun local invoke ${serviceName}/${functionName} -d ${debugPort} -e ${eventFilePath}`
+    const command =
+      `fun local invoke ${serviceName}/${functionName} -d ${debugPort} -e ${eventFilePath.replace(/ /g, '\\ ')}`
     terminal.sendText(command);
     terminal.show();
     return terminal;

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -10,3 +10,16 @@ export function error(message: any) {
   channel.appendLine(message);
   channel.show();
 }
+
+export async function output(func: () => Promise<any>) {
+  const oldLog = console.log;
+  const oldErr = console.error;
+  console.log = log;
+  console.error = error;
+  try {
+    return await func();
+  } finally {
+    console.log = oldLog;
+    console.error = oldErr;
+  }
+}


### PR DESCRIPTION
re #16

将 eventFilePath 在 Terminal 中的空格替换为转义后的空格

![image](https://user-images.githubusercontent.com/19430792/61886064-93d55200-af31-11e9-9b83-0a7a1adde224.png)
