### PR TITLE
perf(Fun): 不依赖 Fun 的安装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,8 +65,9 @@
       }
     },
     "@alicloud/fun": {
-      "version": "git://github.com/alibaba/funcraft.git#6af7b5f1cb0577f42517c07d9b69d530719864c9",
-      "from": "git://github.com/alibaba/funcraft.git#6af7b5f1cb0577f42517c07d9b69d530719864c9",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@alicloud/fun/-/fun-2.16.1.tgz",
+      "integrity": "sha512-CX9iYDrt2wANuV3EZUrqzVujyV49fJfJTeqLkzrfY7WV/dPKdUB41ZsMa/WzgV4f3iEJZELqse9boq1FGibqdQ==",
       "requires": {
         "@alicloud/cloudapi": "^1.0.0",
         "@alicloud/fc": "^1.2.3",
@@ -89,8 +90,10 @@
         "dev-null": "^0.1.1",
         "dockerode": "^2.5.7",
         "dotenv": "^6.0.0",
+        "es6-promise-pool": "^2.5.0",
         "express": "^4.16.4",
         "findit2": "^2.2.3",
+        "fs-extra": "^8.1.0",
         "get-stdin": "^6.0.0",
         "git-ignore-parser": "0.0.2",
         "glob": "^7.1.2",
@@ -105,13 +108,16 @@
         "jszip": "^3.1.5",
         "kitx": "^1.2.1",
         "lodash": "^4.17.11",
+        "md5-file": "^4.0.0",
         "memory-streams": "^0.1.3",
         "mkdirp-promise": "^5.0.1",
         "nested-object-assign": "^1.0.3",
         "node-machine-id": "^1.1.10",
+        "node-stream-zip": "^1.8.2",
         "node-watch": "^0.6.0",
         "os-locale": "^2.1.0",
         "os-name": "^3.1.0",
+        "ping": "^0.2.2",
         "progress": "^2.0.3",
         "promise-retry": "^1.1.1",
         "raw-body": "^2.3.3",
@@ -119,9 +125,11 @@
         "rimraf": "^2.6.2",
         "semver": "^5.5.0",
         "single-line-log": "^1.1.2",
+        "split-file": "^2.1.1",
+        "supertest": "^4.0.2",
         "tablestore": "^4.3.2",
         "universal-analytics": "^0.4.20",
-        "unzipper": "^0.10.1",
+        "unzipper": "^0.10.2",
         "update-notifier": "^3.0.0",
         "urlencode": "^1.1.0"
       },
@@ -348,10 +356,39 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/decompress": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.3.tgz",
+      "integrity": "sha512-W24e3Ycz1UZPgr1ZEDHlK4XnvOr+CpJH3qNsFeqXwwlW/9END9gxn3oJSsp7gYdiQxrXUHwUUd3xuzVz37MrZQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/download": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/@types/download/-/download-6.2.4.tgz",
+      "integrity": "sha512-Lo5dy3ai6LNnbL663sgdzqL1eib11u1yKH6w3v3IXEOO4kRfQpMn1qWUTaumcHLACjFp1RcBx9tUXEvJoR3vcA==",
+      "dev": true,
+      "requires": {
+        "@types/decompress": "*",
+        "@types/got": "^8",
+        "@types/node": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag=="
+    },
+    "@types/got": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/@types/got/-/got-8.3.5.tgz",
+      "integrity": "sha512-AaXSrIF99SjjtPVNmCmYb388HML+PKEJb/xmj4SbL2ZO0hHuETZZzyDIKfOqaEoAHZEuX4sC+FRFrHYJoIby6A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/js-yaml": {
       "version": "3.12.1",
@@ -379,6 +416,15 @@
       "resolved": "https://registry.npmjs.org/@types/universal-analytics/-/universal-analytics-0.4.2.tgz",
       "integrity": "sha512-ndv0aYA5tNPdl4KYUperlswuiSj49+o7Pwx8hrCiE9x2oeiMrn7A2jXFDdTLFIymiYZImDX02ycq0i6uQ3TL0A==",
       "dev": true
+    },
+    "@types/unzipper": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@types/unzipper/-/unzipper-0.10.0.tgz",
+      "integrity": "sha512-GZL5vt0o9ZAST+7ge1Sirzc14EEJFbq6kib24nS0UglY6BHX8ERhA8cBq4XsYWcGK212FtMBZyJz6AwPvrhGLQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/uuid": {
       "version": "3.4.5",
@@ -548,6 +594,21 @@
         "color-convert": "^1.9.0"
       }
     },
+    "archive-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-4.0.0.tgz",
+      "integrity": "sha1-+S5yIzBW38aWlHJ0nCZ72wRrHXA=",
+      "requires": {
+        "file-type": "^4.2.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+          "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
+        }
+      }
+    },
     "archiver": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
@@ -667,9 +728,9 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -708,9 +769,9 @@
       }
     },
     "bluebird": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -954,6 +1015,17 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "caw": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/caw/-/caw-2.0.1.tgz",
+      "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
+      "requires": {
+        "get-proxy": "^2.0.0",
+        "isurl": "^1.0.0-alpha5",
+        "tunnel-agent": "^0.6.0",
+        "url-to-options": "^1.0.1"
+      }
+    },
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -1103,6 +1175,11 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+    },
     "compress-commons": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
@@ -1142,6 +1219,15 @@
         "make-dir": "^3.0.0",
         "pkg-up": "^3.0.1",
         "write-file-atomic": "^3.0.0"
+      }
+    },
+    "config-chain": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
+      "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
       }
     },
     "configstore": {
@@ -1213,6 +1299,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "cookiejar": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+    },
     "core-js": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
@@ -1283,12 +1374,139 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "decompress": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+      "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
+      "requires": {
+        "decompress-tar": "^4.0.0",
+        "decompress-tarbz2": "^4.0.0",
+        "decompress-targz": "^4.0.0",
+        "decompress-unzip": "^4.0.1",
+        "graceful-fs": "^4.1.10",
+        "make-dir": "^1.0.0",
+        "pify": "^2.3.0",
+        "strip-dirs": "^2.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+            }
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
+      }
+    },
     "decompress-response": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
         "mimic-response": "^1.0.0"
+      }
+    },
+    "decompress-tar": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
+      "requires": {
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0",
+        "tar-stream": "^1.5.2"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+        }
+      }
+    },
+    "decompress-tarbz2": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
+      "requires": {
+        "decompress-tar": "^4.1.0",
+        "file-type": "^6.1.0",
+        "is-stream": "^1.1.0",
+        "seek-bzip": "^1.0.5",
+        "unbzip2-stream": "^1.0.9"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
+        }
+      }
+    },
+    "decompress-targz": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
+      "requires": {
+        "decompress-tar": "^4.1.1",
+        "file-type": "^5.2.0",
+        "is-stream": "^1.1.0"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+          "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
+        }
+      }
+    },
+    "decompress-unzip": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+      "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
+      "requires": {
+        "file-type": "^3.8.0",
+        "get-stream": "^2.2.0",
+        "pify": "^2.3.0",
+        "yauzl": "^2.4.2"
+      },
+      "dependencies": {
+        "file-type": {
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
+        },
+        "get-stream": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+        }
       }
     },
     "deep-extend": {
@@ -1407,6 +1625,121 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
       "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
     },
+    "download": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/download/-/download-7.1.0.tgz",
+      "integrity": "sha512-xqnBTVd/E+GxJVrX5/eUJiLYjCGPwMpdL+jGhGU57BvtcA7wwhtHVbXBeUk51kOpW3S7Jn3BQbN9Q1R1Km2qDQ==",
+      "requires": {
+        "archive-type": "^4.0.0",
+        "caw": "^2.0.1",
+        "content-disposition": "^0.5.2",
+        "decompress": "^4.2.0",
+        "ext-name": "^5.0.0",
+        "file-type": "^8.1.0",
+        "filenamify": "^2.0.0",
+        "get-stream": "^3.0.0",
+        "got": "^8.3.1",
+        "make-dir": "^1.2.0",
+        "p-event": "^2.1.0",
+        "pify": "^3.0.0"
+      },
+      "dependencies": {
+        "@sindresorhus/is": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+          "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+        },
+        "cacheable-request": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+          "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+          "requires": {
+            "clone-response": "1.0.2",
+            "get-stream": "3.0.0",
+            "http-cache-semantics": "3.8.1",
+            "keyv": "3.0.0",
+            "lowercase-keys": "1.0.0",
+            "normalize-url": "2.0.1",
+            "responselike": "1.0.2"
+          },
+          "dependencies": {
+            "lowercase-keys": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+            }
+          }
+        },
+        "got": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+          "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+          "requires": {
+            "@sindresorhus/is": "^0.7.0",
+            "cacheable-request": "^2.1.1",
+            "decompress-response": "^3.3.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "into-stream": "^3.1.0",
+            "is-retry-allowed": "^1.1.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "mimic-response": "^1.0.0",
+            "p-cancelable": "^0.4.0",
+            "p-timeout": "^2.0.1",
+            "pify": "^3.0.0",
+            "safe-buffer": "^5.1.1",
+            "timed-out": "^4.0.1",
+            "url-parse-lax": "^3.0.0",
+            "url-to-options": "^1.0.1"
+          }
+        },
+        "http-cache-semantics": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+        },
+        "keyv": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+          "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+          "requires": {
+            "json-buffer": "3.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "normalize-url": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+          "requires": {
+            "prepend-http": "^2.0.0",
+            "query-string": "^5.0.1",
+            "sort-keys": "^2.0.0"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+          "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+        },
+        "sort-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        }
+      }
+    },
     "duplexer2": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -1467,6 +1800,11 @@
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
+    },
+    "es6-promise-pool": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz",
+      "integrity": "sha1-FHxhKza0fxBQJ/nSv1SlmKmdnMs="
     },
     "es6-promisify": {
       "version": "5.0.0",
@@ -1702,6 +2040,23 @@
         }
       }
     },
+    "ext-list": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+      "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "requires": {
+        "mime-db": "^1.28.0"
+      }
+    },
+    "ext-name": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+      "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+      "requires": {
+        "ext-list": "^2.0.0",
+        "sort-keys-length": "^1.0.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1739,6 +2094,14 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -1754,6 +2117,26 @@
       "dev": true,
       "requires": {
         "flat-cache": "^2.0.1"
+      }
+    },
+    "file-type": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
+      "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
+    },
+    "filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
+    },
+    "filenamify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-2.1.0.tgz",
+      "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
+      "requires": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
       }
     },
     "finalhandler": {
@@ -1830,6 +2213,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -1840,10 +2228,29 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1865,6 +2272,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
+    },
+    "get-proxy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/get-proxy/-/get-proxy-2.1.0.tgz",
+      "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
+      "requires": {
+        "npm-conf": "^1.1.0"
+      }
     },
     "get-stdin": {
       "version": "6.0.0",
@@ -1980,9 +2395,14 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
+      "integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw=="
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "growl": {
       "version": "1.10.3",
@@ -2008,6 +2428,19 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
+      }
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -2230,6 +2663,15 @@
       "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.9.tgz",
       "integrity": "sha1-ngOdoEOyT3ixlrKD4EZT716ZD2E="
     },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "requires": {
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
+      }
+    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -2282,6 +2724,11 @@
         "is-path-inside": "^1.0.0"
       }
     },
+    "is-natural-number": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+      "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
+    },
     "is-npm": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-3.0.0.tgz",
@@ -2292,6 +2739,11 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
     },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -2300,10 +2752,20 @@
         "path-is-inside": "^1.0.1"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -2339,6 +2801,15 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -2407,6 +2878,14 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsonparse": {
       "version": "1.3.1",
@@ -2557,6 +3036,11 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
+    },
+    "md5-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
+      "integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -2781,6 +3265,11 @@
       "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
       "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="
     },
+    "node-stream-zip": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/node-stream-zip/-/node-stream-zip-1.8.2.tgz",
+      "integrity": "sha512-zwP2F/R28Oqtl0gOLItk5QjJ6jEU8XO4kaUMgeqvCyXPgdCZlm8T/5qLMiNy+moJCBCiMQAaX7aVMRhT0t2vkQ=="
+    },
     "node-watch": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.6.2.tgz",
@@ -2799,6 +3288,15 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.3.0.tgz",
       "integrity": "sha512-0NLtR71o4k6GLP+mr6Ty34c5GA6CMoEsncKJxvQd8NzPxaHRJNnb5gZE8R1XF4CPIS7QPHLJ74IFszwtNVAHVQ=="
     },
+    "npm-conf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/npm-conf/-/npm-conf-1.1.3.tgz",
+      "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
+      "requires": {
+        "config-chain": "^1.1.11",
+        "pify": "^3.0.0"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -2816,6 +3314,11 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -2897,10 +3400,23 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
     },
+    "p-event": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-2.3.1.tgz",
+      "integrity": "sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==",
+      "requires": {
+        "p-timeout": "^2.0.1"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
     "p-limit": {
       "version": "2.2.0",
@@ -2916,6 +3432,14 @@
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
         "p-limit": "^2.0.0"
+      }
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "p-try": {
@@ -2997,6 +3521,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -3006,6 +3535,28 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+    },
+    "ping": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/ping/-/ping-0.2.2.tgz",
+      "integrity": "sha1-GA+3UIwdx0eThJvONcgHP5llvOI=",
+      "requires": {
+        "q": "1.x",
+        "underscore": "^1.8.3"
+      }
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "pkg-up": {
       "version": "3.1.0",
@@ -3044,6 +3595,11 @@
         "err-code": "^1.0.0",
         "retry": "^0.10.0"
       }
+    },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
     },
     "protobufjs": {
       "version": "6.8.8",
@@ -3098,10 +3654,25 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
     },
     "querystringify": {
       "version": "2.1.1",
@@ -3329,6 +3900,24 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
+    "seek-bzip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+      "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+      "requires": {
+        "commander": "~2.8.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
+          "requires": {
+            "graceful-readlink": ">= 1.0.0"
+          }
+        }
+      }
+    },
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -3480,6 +4069,22 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
+    "sort-keys-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+      "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+      "requires": {
+        "sort-keys": "^1.0.0"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3500,6 +4105,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
       "integrity": "sha1-bIOv82kvphJW4M0ZfgXp3hV2kaY="
+    },
+    "split-file": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/split-file/-/split-file-2.1.1.tgz",
+      "integrity": "sha512-wldYN8h4mff6wPvQ/Oj6QZTfo8ZcdV4TSViGuZi6jnZcrJi0PsN1Xmxvrd03IrtyzuxK60EVa2b2kjsIUHWwmA==",
+      "requires": {
+        "bluebird": "^3.5.3"
+      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -3527,6 +4140,11 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -3552,6 +4170,14 @@
         "ansi-regex": "^3.0.0"
       }
     },
+    "strip-dirs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
+      "requires": {
+        "is-natural-number": "^4.0.1"
+      }
+    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -3561,6 +4187,40 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "superagent": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "requires": {
+        "component-emitter": "^1.2.0",
+        "cookiejar": "^2.1.0",
+        "debug": "^3.1.0",
+        "extend": "^3.0.0",
+        "form-data": "^2.3.1",
+        "formidable": "^1.2.0",
+        "methods": "^1.1.1",
+        "mime": "^1.4.1",
+        "qs": "^6.5.1",
+        "readable-stream": "^2.3.5"
+      }
+    },
+    "supertest": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-4.0.2.tgz",
+      "integrity": "sha512-1BAbvrOZsGA3YTCWqbmh14L0YEq0EGICX/nBnfkfVJn7SrxQV1I3pMYjSzG9y/7ZU2V9dWqyqk2POwxlb09duQ==",
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^3.8.3"
+      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -3704,6 +4364,11 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -3747,6 +4412,14 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
     },
     "tslib": {
       "version": "1.10.0",
@@ -3867,6 +4540,20 @@
         }
       }
     },
+    "unbzip2-stream": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
+      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      }
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
@@ -3885,15 +4572,20 @@
         "uuid": "^3.0.0"
       }
     },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unzipper": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.1.tgz",
-      "integrity": "sha512-ft0sDT8S/LVNKSOP2dYS3zl4aSw9lAtLY9w9XdNy3Cnt//+SvmTYo+OT7dT9b0C/eg/Ky+BARgWgaibq19ewcA==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.3.tgz",
+      "integrity": "sha512-vH3+KAfi01r2wioCve0djy0NRpQUfjVFoLWdsup8u6xdCId2vn8TEDReRfYGjdGuVQ/2aEDaWgeRJCcPOsRHqw==",
       "requires": {
         "big-integer": "^1.6.17",
         "binary": "~0.3.0",
@@ -3904,6 +4596,13 @@
         "listenercount": "~1.0.1",
         "readable-stream": "~2.3.6",
         "setimmediate": "~1.0.4"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+          "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM="
+        }
       }
     },
     "update-notifier": {
@@ -3950,6 +4649,11 @@
       "requires": {
         "prepend-http": "^2.0.0"
       }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
     },
     "urlencode": {
       "version": "1.1.0",
@@ -4241,6 +4945,15 @@
             "ansi-regex": "^2.0.0"
           }
         }
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "zip-stream": {

--- a/package.json
+++ b/package.json
@@ -356,9 +356,11 @@
     "lint": "./node_modules/.bin/eslint src --ext .ts"
   },
   "devDependencies": {
+    "@types/download": "^6.2.4",
     "@types/mocha": "^2.2.42",
     "@types/node": "^10.14.9",
     "@types/universal-analytics": "^0.4.2",
+    "@types/unzipper": "^0.10.0",
     "@types/uuid": "^3.4.5",
     "eslint": "^6.0.1",
     "eslint-plugin-typescript": "^0.14.0",
@@ -369,13 +371,15 @@
   },
   "dependencies": {
     "@alicloud/fc2": "^2.1.0",
-    "@alicloud/fun": "git://github.com/alibaba/funcraft.git#6af7b5f1cb0577f42517c07d9b69d530719864c9",
+    "@alicloud/fun": "^2.16.1",
     "@types/js-yaml": "^3.12.1",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
+    "download": "^7.1.0",
     "js-yaml": "^3.13.1",
     "open": "^6.3.0",
     "universal-analytics": "^0.4.20",
+    "unzipper": "^0.10.3",
     "uuid": "^3.3.2",
     "yaml-ast-parser": "0.0.43"
   }

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,7 +1,5 @@
 import * as vscode from 'vscode';
-import * as open from 'open';
-import { serverlessCommands, FUN_INSTALL_URL } from '../utils/constants';
-import { validateFunInstalled } from '../validate/validateFunInstalled';
+import { serverlessCommands } from '../utils/constants';
 import { recordPageView } from '../utils/visitor';
 import { FunService } from '../services/FunService';
 
@@ -9,15 +7,6 @@ export function deploy(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand(serverlessCommands.SERVICE_DEPLOY.id,
     async () => {
       recordPageView('/deployService');
-      if (! await validateFunInstalled()) {
-        vscode.window.showInformationMessage('You should install "@alicloud/fun" first', 'Goto', 'Cancel')
-          .then(choice => {
-            if (choice === 'Goto') {
-              open(FUN_INSTALL_URL);
-            }
-          });
-        return;
-      }
       await process();
     })
   );

--- a/src/commands/localDebugFunction.ts
+++ b/src/commands/localDebugFunction.ts
@@ -1,10 +1,8 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as open from 'open';
 import * as rt from '../utils/runtime';
-import { serverlessCommands, FUN_INSTALL_URL } from '../utils/constants';
-import { validateFunInstalled } from '../validate/validateFunInstalled';
+import { serverlessCommands } from '../utils/constants';
 import { isPathExists, createDirectory, createLaunchFile, createEventFile } from '../utils/file';
 import { recordPageView } from '../utils/visitor';
 import { FunService } from '../services/FunService';
@@ -17,15 +15,6 @@ export function localDebugFunction(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand(serverlessCommands.LOCAL_DEBUG.id,
     async (node: Resource) => {
       recordPageView('/localDebug');
-      if (! await validateFunInstalled()) {
-        vscode.window.showInformationMessage('You should install "@alicloud/fun" first', 'Goto', 'Cancel')
-          .then(choice => {
-            if (choice === 'Goto') {
-              open(FUN_INSTALL_URL);
-            }
-          });
-        return;
-      }
       const serviceName = node.resourceProperties && node.resourceProperties.serviceName
         ? node.resourceProperties.serviceName : '';
       const functionName = node.label;

--- a/src/commands/localInvokeFunction.ts
+++ b/src/commands/localInvokeFunction.ts
@@ -1,9 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as open from 'open';
-import { serverlessCommands, FUN_INSTALL_URL } from '../utils/constants';
-import { validateFunInstalled } from '../validate/validateFunInstalled';
+import { serverlessCommands } from '../utils/constants';
 import { isPathExists, createEventFile } from '../utils/file';
 import { recordPageView } from '../utils/visitor';
 import { FunService } from '../services/FunService';
@@ -14,15 +12,6 @@ export function localInvokeFunction(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand(serverlessCommands.LOCAL_RUN.id,
     async (node: Resource) => {
       recordPageView('/localInvoke');
-      if (! await validateFunInstalled()) {
-        vscode.window.showInformationMessage('You should install "@alicloud/fun" first', 'Goto', 'Cancel')
-          .then(choice => {
-            if (choice === 'Goto') {
-              open(FUN_INSTALL_URL);
-            }
-          });
-        return;
-      }
       const serviceName = node.resourceProperties && node.resourceProperties.serviceName
         ? node.resourceProperties.serviceName : '';
       const functionName = node.label;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { ext } from './extensionVariables';
 import { serverlessCommands } from './utils/constants';
 import { recordPageView } from './utils/visitor';
 import { initProject } from './commands/initProject';
@@ -33,7 +34,7 @@ import { showUpdateNotification } from './commands/showUpdateNotification';
 
 export function activate(context: vscode.ExtensionContext) {
   recordPageView('/');
-
+  ext.context = context;
   const cwd = vscode.workspace.rootPath;
 
   const localResourceProvider = new LocalResourceProvider(cwd);

--- a/src/extensionVariables.ts
+++ b/src/extensionVariables.ts
@@ -1,0 +1,5 @@
+import * as vscode from 'vscode';
+
+export namespace ext {
+  export let context: vscode.ExtensionContext;
+}

--- a/src/services/FunService.ts
+++ b/src/services/FunService.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import * as terminalService from '../utils/terminal';
 import * as open from 'open';
+import * as path from 'path';
+import { getFunPath } from '../utils/fun';
 
 export class FunService {
   constructor (private workspace: string) {
@@ -12,66 +14,85 @@ export class FunService {
     if (!this.validateInitRumtime(runtime)) {
       vscode.window.showErrorMessage(`${runtime} is not valid runtime`);
     }
-    const command = `fun init helloworld-${runtime}`;
-    terminal.sendText(command);
-    terminal.show();
+    getFunPath().then(funPath => {
+      const command = `${funPath} init helloworld-${runtime}`;
+      terminal.sendText(command);
+      terminal.show();
+    })
   }
 
   deploy() {
     const terminal = terminalService.getFunctionComputeTerminal();
-    const command = 'fun deploy -t ./template.yml';
-    terminal.sendText(command);
-    terminal.show();
+    getFunPath().then(funPath => {
+      const command = `${funPath} deploy -t ./template.yml`;
+      terminal.sendText(command);
+      terminal.show();
+    })
   }
 
   localInvoke(serviceName: string, functionName: string, eventFilePath: string) {
     const terminal =  terminalService.getFunctionComputeTerminal();
-    const command = `fun local invoke ${serviceName}/${functionName} -e ${eventFilePath.replace(/ /g, '\\ ')}`
-    terminal.sendText(command);
-    terminal.show();
+    getFunPath().then(funPath => {
+      const command =
+  `${funPath} local invoke ${serviceName}/${functionName} -e ${this.escapeSpace(eventFilePath)}`
+      terminal.sendText(command);
+      terminal.show();
+    })
   }
 
   localInvokeDebug(serviceName: string, functionName: string,
     debugPort: string, eventFilePath: string): vscode.Terminal {
     const terminal =  terminalService.getFunctionComputeTerminal();
-    const command =
-      `fun local invoke ${serviceName}/${functionName} -d ${debugPort} -e ${eventFilePath.replace(/ /g, '\\ ')}`
-    terminal.sendText(command);
-    terminal.show();
+    getFunPath().then(funPath => {
+      /* eslint-disable max-len */
+      const command =
+    `${funPath} local invoke ${serviceName}/${functionName} -d ${debugPort} -e ${this.escapeSpace(eventFilePath)}`
+      terminal.sendText(command);
+      terminal.show();
+    })
     return terminal;
   }
 
   localStart(serviceName: string, functionName: string) {
     const terminal = terminalService.getFunctionComputeTerminal();
-    let command = 'fun local start';
-    terminal.sendText(command);
+    getFunPath().then(funPath => {
+      let command = `${funPath} local start`;
+      terminal.sendText(command);
 
-    setTimeout(() => {
-      const workerTerminal = terminalService.getFunctionComputeWorkderTerminal();
-      command = `open http://localhost:8000/2016-08-15/proxy/${serviceName}/${functionName}/`;
-      workerTerminal.sendText(command);
-    }, 2000);
+      setTimeout(() => {
+        (async () => {
+          await open(`http://localhost:8000/2016-08-15/proxy/${serviceName}/${functionName}/`)
+        })()
+      }, 2000);
 
-    terminal.show();
+      terminal.show();
+    })
   }
 
   localStartDebug(serviceName: string, functionName: string, debugPort: string): vscode.Terminal {
     const terminal = terminalService.getFunctionComputeTerminal();
-    let command = `fun local start -d ${debugPort}`;
-    terminal.sendText(command);
+    getFunPath().then(funPath => {
+      let command = `${funPath} local start -d ${debugPort}`;
+      terminal.sendText(command);
 
-    setTimeout(() => {
-      (async () => {
-        await open(`http://localhost:8000/2016-08-15/proxy/${serviceName}/${functionName}/`)
-      })()
-    }, 2000);
+      setTimeout(() => {
+        (async () => {
+          await open(`http://localhost:8000/2016-08-15/proxy/${serviceName}/${functionName}/`)
+        })()
+      }, 2000);
 
-    terminal.show();
+      terminal.show();
+    })
+
     return terminal;
   }
 
   private validateInitRumtime(runtime: string): boolean {
     const runtimes = ['nodejs8', 'nodejs6', 'python3', 'python2.7', 'java8', 'php7.2'];
     return runtimes.includes(runtime);
+  }
+
+  private escapeSpace(str: string): string {
+    return str.replace(/ /g, '\\ ');
   }
 }

--- a/src/utils/fun.ts
+++ b/src/utils/fun.ts
@@ -1,0 +1,154 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import * as os from 'os';
+import * as fs from 'fs';
+import * as download from 'download';
+import * as unzipper from 'unzipper';
+import { cpUtils  } from './cpUtils';
+import { createFile, isPathExists, createDirectory } from './file';
+import { ext } from '../extensionVariables';
+
+const FUN_VERSION = '2.16.1';
+
+abstract class FunExecutorGenerator {
+  async generate(): Promise<string>  {
+    if (!this.exists() || await this.needUpdate()) {
+      await this.doGenerate();
+    }
+    return this.getPlatformFunPath();
+  }
+  exists(): boolean {
+    const funPath = this.getFunPath();
+    return isPathExists(funPath);
+  }
+  getFunPath(): string {
+    const funFileName = this.getExecuteFileName();
+    return path.resolve(os.homedir(), '.aliyun-serverless', 'bin', funFileName);
+  }
+  getPlatformFunPath(): string {
+    return this.getFunPath();
+  }
+  abstract getExecuteFileName(): string;
+  abstract async needUpdate(): Promise<boolean>;
+  abstract async doGenerate(): Promise<boolean>;
+}
+
+class PosixFunExecutorGenerator extends FunExecutorGenerator {
+  getExecuteFileName(): string {
+    return 'fun.sh';
+  }
+  async needUpdate(): Promise<boolean> {
+    const funPath = this.getFunPath();
+    try {
+      const electronPath = await cpUtils.executeCommand(undefined, undefined, `${funPath}`, '--electron-path');
+      return process.argv0 !== electronPath.trim();
+    } catch (ex) {
+      return true;
+    }
+  }
+  async doGenerate(): Promise<boolean> {
+    const funEntryPath = path.resolve(ext.context.extensionPath, 'node_modules', '@alicloud', 'fun', 'bin', 'fun.js');
+    const electronPath = process.argv0;
+    const funPath = this.getFunPath();
+    if (!isPathExists(funPath)) {
+      if (!createFile(funPath)) {
+        throw new Error(`Create ${funPath} fail`);
+      }
+    }
+    try {
+      fs.writeFileSync(
+        funPath,
+        fs.readFileSync(
+          path.resolve(ext.context.extensionPath, 'templates', 'fun.sh'), 'utf8')
+          .replace('{{ELECTRON}}', electronPath.replace(/ /g, '\ '))
+          .replace('{{FUN}}', funEntryPath)
+      )
+      fs.chmodSync(funPath, 0o755);
+    } catch (err) {
+      vscode.window.showErrorMessage(err.message);
+      throw(err);
+    }
+
+    return true;
+  }
+  getPlatformFunPath(): string {
+    return path.join('~', '.aliyun-serverless', 'bin', this.getExecuteFileName());
+  }
+}
+
+class WindowsFunExecutorGenerator extends FunExecutorGenerator {
+  getExecuteFileName(): string {
+    return 'fun.exe';
+  }
+
+  async needUpdate(): Promise<boolean> {
+    const funPath = this.getFunPath();
+    try {
+      const version = await cpUtils.executeCommand(undefined, undefined, `${funPath}`, '--version');
+      return version.trim() !== FUN_VERSION;
+    } catch (ex) {
+      return true;
+    }
+  }
+
+  async doGenerate(): Promise<boolean> {
+    const funPath = this.getFunPath();
+    if (!isPathExists(path.dirname(funPath))) {
+      if (!createDirectory(path.dirname(funPath))) {
+        throw new Error(`Create ${path.dirname(funPath)} fail`)
+      }
+    }
+    const funFileName = `fun-v${FUN_VERSION}-win-${process.arch === 'x64' ? 'x64' : 'x86'}.exe`;
+    vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+      },
+      () => {
+        return vscode.window.showInformationMessage(
+          `Downloading ${funFileName}...`,
+          'OK',
+        );
+      }
+    );
+    await new Promise((resolve, reject) => {
+      download(`https://gosspublic.alicdn.com/fun/${funFileName}.zip`)
+        .pipe(unzipper.Parse())
+        .on('entry', (entry) => {
+          const fileName = entry.path;
+          if (fileName === funFileName) {
+            entry.pipe(fs.createWriteStream(funPath, { flags: 'w' }));
+          } else {
+            entry.autodrain();
+          }
+        })
+        .on('finish', () => {
+          resolve(funPath);
+        })
+        .on('error', (err) => {
+          reject(err);
+        });
+    }).catch(err => {
+      vscode.window.showErrorMessage(err.message);
+      throw(err);
+    });
+    return true;
+  }
+
+  getPlatformFunPath(): string {
+    const terminal = vscode.workspace.getConfiguration().get('terminal.integrated.shell.windows') as string;
+    if (terminal && terminal.indexOf('cmd') > -1) {
+      return path.win32.join('%USERPROFILE%', '.aliyun-serverless', 'bin', 'fun.exe');
+    }
+    return path.posix.join('~', '.aliyun-serverless', 'bin', 'fun.exe');
+  }
+}
+
+export async function getFunPath(): Promise<string> {
+  let funExecutorGenerator: FunExecutorGenerator;
+  if (os.platform() === 'win32') {
+    funExecutorGenerator = new WindowsFunExecutorGenerator();
+  } else {
+    funExecutorGenerator = new PosixFunExecutorGenerator();
+  }
+  return funExecutorGenerator.generate();
+}

--- a/templates/fun.sh
+++ b/templates/fun.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+ELECTRON="{{ELECTRON}}"
+FUN="{{FUN}}"
+
+if [ $1x == '--electron-path'x ]; then
+  echo $ELECTRON
+  exit 0
+fi
+
+ELECTRON_RUN_AS_NODE=1 exec "$ELECTRON" "$FUN" "$@"


### PR DESCRIPTION
re #28

安装运行策略：
1. 针对 posix 平台，通过利用 vscode 的 electron 作为 node 运行插件倚赖中 fun 的入口文件
2. 针对 windows 平台，自动根据系统 x86 或 x64 下载对应的 fun 可执行文件

更新策略：
1. 针对 posix 平台，检测 electron 路径
2. 针对 widnows 平台，检测 fun 版本