### PR TITLE
feat(External Fun): 允许配置外部 Fun Path 从而替代内部 Fun

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,10 @@
           "type": "string",
           "default": "./event.dat",
           "description": "Function Compute remote resource event file path"
+        },
+        "aliyun.fc.fun.path": {
+          "type": "string",
+          "description": "External Fun command which will replace the internal Fun"
         }
       }
     },

--- a/src/utils/fun.ts
+++ b/src/utils/fun.ts
@@ -136,6 +136,10 @@ class WindowsFunExecutorGenerator extends FunExecutorGenerator {
 }
 
 export async function getFunPath(): Promise<string> {
+  const externalFunPath = getExternalFunPath();
+  if (externalFunPath) {
+    return externalFunPath;
+  }
   let funExecutorGenerator: FunExecutorGenerator;
   if (os.platform() === 'win32') {
     funExecutorGenerator = new WindowsFunExecutorGenerator();
@@ -143,4 +147,12 @@ export async function getFunPath(): Promise<string> {
     funExecutorGenerator = new PosixFunExecutorGenerator();
   }
   return funExecutorGenerator.generate();
+}
+
+function getExternalFunPath(): string | undefined {
+  const externalFunPath = vscode.workspace.getConfiguration().get('aliyun.fc.fun.path');
+  if (typeof externalFunPath === 'string') {
+    return externalFunPath;
+  }
+  return;
 }


### PR DESCRIPTION
re #55

![allow-other-fun](https://user-images.githubusercontent.com/19430792/62912317-3c046b00-bdba-11e9-95e5-c06ec4bae5f4.gif)
