### PR TITLE
fix(Adapt Latest VSC & Update Fun Download URL)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -193,12 +193,83 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
           "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow=="
         },
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "docker-modem": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-1.0.9.tgz",
+          "integrity": "sha512-lVjqCSCIAUDZPAZIeyM125HXfNvOmYYInciphNrLrylUtKyW66meAjSPXWchKVzoIYZx69TPnAepVSSkeawoIw==",
+          "requires": {
+            "JSONStream": "1.3.2",
+            "debug": "^3.2.6",
+            "readable-stream": "~1.0.26-4",
+            "split-ca": "^1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.2.6",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "dockerode": {
+          "version": "2.5.8",
+          "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-2.5.8.tgz",
+          "integrity": "sha512-+7iOUYBeDTScmOmQqpUYQaE7F4vvIt6+gIZNHWhqAQEI887tiPFB9OvXI/HzQYqfUNvukMK+9myLW63oTJPZpw==",
+          "requires": {
+            "concat-stream": "~1.6.2",
+            "docker-modem": "^1.0.8",
+            "tar-fs": "~1.16.3"
+          },
+          "dependencies": {
+            "tar-fs": {
+              "version": "1.16.3",
+              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+              "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+              "requires": {
+                "chownr": "^1.0.1",
+                "mkdirp": "^0.5.1",
+                "pump": "^1.0.0",
+                "tar-stream": "^1.1.2"
+              }
+            }
           }
         },
         "dotenv": {
@@ -210,6 +281,11 @@
           "version": "5.1.4",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
           "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "mem": {
           "version": "1.1.0",
@@ -233,6 +309,20 @@
             "lcid": "^1.0.0",
             "mem": "^1.1.0"
           }
+        },
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -399,6 +489,15 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@types/decompress/-/decompress-4.2.3.tgz",
       "integrity": "sha512-W24e3Ycz1UZPgr1ZEDHlK4XnvOr+CpJH3qNsFeqXwwlW/9END9gxn3oJSsp7gYdiQxrXUHwUUd3xuzVz37MrZQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/dockerode": {
+      "version": "2.5.20",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-2.5.20.tgz",
+      "integrity": "sha512-g2eM9q+pur7iZc897K/OSq8sCL7VdVcCPzNkdeTukUokfvgl3TaP+nT7G8BMpnSSojrJFKl7VdTciP7hbVgfKA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1290,14 +1389,26 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
+        "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "conf": {
@@ -1748,14 +1859,15 @@
       }
     },
     "docker-modem": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-1.0.9.tgz",
-      "integrity": "sha512-lVjqCSCIAUDZPAZIeyM125HXfNvOmYYInciphNrLrylUtKyW66meAjSPXWchKVzoIYZx69TPnAepVSSkeawoIw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-2.0.2.tgz",
+      "integrity": "sha512-Aq6NBJQm5najFlg4wRZtSrWXzQbQClh1kccAkUWIdVhuyHK6tYhmi9W9xtVaGmzBa0Nfuwi4AEbQzWtHZT+2Jw==",
       "requires": {
         "JSONStream": "1.3.2",
         "debug": "^3.2.6",
         "readable-stream": "~1.0.26-4",
-        "split-ca": "^1.0.0"
+        "split-ca": "^1.0.0",
+        "ssh2": "^0.8.5"
       },
       "dependencies": {
         "isarray": {
@@ -1790,35 +1902,13 @@
       }
     },
     "dockerode": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-2.5.8.tgz",
-      "integrity": "sha512-+7iOUYBeDTScmOmQqpUYQaE7F4vvIt6+gIZNHWhqAQEI887tiPFB9OvXI/HzQYqfUNvukMK+9myLW63oTJPZpw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-3.0.2.tgz",
+      "integrity": "sha512-jql7zwTQH2psjyevyeWOpe9XJ8x1WbXX/TwKHcWlJsq1jivxN2+1nVqT72HKE9xxNR/MGcuWcPxrCBHNu9GZpw==",
       "requires": {
-        "concat-stream": "~1.6.2",
-        "docker-modem": "^1.0.8",
-        "tar-fs": "~1.16.3"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
-        "tar-fs": {
-          "version": "1.16.3",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-          "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
-          "requires": {
-            "chownr": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pump": "^1.0.0",
-            "tar-stream": "^1.1.2"
-          }
-        }
+        "concat-stream": "~2.0.0",
+        "docker-modem": "^2.0.0",
+        "tar-fs": "~2.0.0"
       }
     },
     "doctrine": {
@@ -4885,6 +4975,24 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "ssh2": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.8.5.tgz",
+      "integrity": "sha512-TkvzxSYYUSQ8jb//HbHnJVui4fVEW7yu/zwBxwro/QaK2EGYtwB+8gdEChwHHuj142c5+250poMC74aJiwApPw==",
+      "requires": {
+        "ssh2-streams": "~0.4.4"
+      }
+    },
+    "ssh2-streams": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/ssh2-streams/-/ssh2-streams-0.4.6.tgz",
+      "integrity": "sha512-jXq/nk2K82HuueO9CTCdas/a0ncX3fvYzEPKt1+ftKwE5RXTX25GyjcpjBh2lwVUYbk0c9yq6cBczZssWmU3Tw==",
+      "requires": {
+        "asn1": "~0.2.0",
+        "bcrypt-pbkdf": "^1.0.2",
+        "streamsearch": "~0.1.2"
+      }
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -4951,6 +5059,11 @@
           "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         }
       }
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "strict-uri-encode": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -582,6 +582,7 @@
     "lint": "./node_modules/.bin/eslint src --ext .ts"
   },
   "devDependencies": {
+    "@types/dockerode": "^2.5.20",
     "@types/dotenv": "^6.1.1",
     "@types/download": "^6.2.4",
     "@types/glob": "^7.1.1",
@@ -606,6 +607,7 @@
     "@typescript-eslint/parser": "^1.11.0",
     "cron-parser": "^2.13.0",
     "cronstrue": "^1.83.0",
+    "dockerode": "^3.0.2",
     "dotenv": "^8.1.0",
     "download": "^7.1.0",
     "glob": "^7.1.4",

--- a/src/utils/fun.ts
+++ b/src/utils/fun.ts
@@ -102,7 +102,7 @@ class WindowsFunExecutorGenerator extends FunExecutorGenerator {
         throw new Error(`Create ${path.dirname(funPath)} fail`)
       }
     }
-    const funFileName = `fun-v${FUN_VERSION}-win-${process.arch === 'x64' ? 'x64' : 'x86'}.exe`;
+    const funFileName = `fun-v${FUN_VERSION}-win.exe`;
     await new Promise((resolve, reject) => {
       download(`https://gosspublic.alicdn.com/fun/${funFileName}.zip`)
         .pipe(unzipper.Parse())


### PR DESCRIPTION
1. 适配 1.39.x 的 vscode，1.39.x 开始取消了 `Terminal.onDidWriteData`，提供 Proposed API `window.onDidWriteTerminalData`
https://code.visualstudio.com/updates/v1_39#_removed-deprecated-terminalondidwritedata-api
Proposed API 只能在 insider 版本用于开发测试，无法在正式对外版本使用，所以使用检测镜像是否存在的方式替换过去监听 Terminal 输出
2. 更新 win 下 fun 的下载地址， 自 3.0.6 版本开始地址变为 `fun-v{版本号}-win.exe`