### PR TITLE
feat(Template Diagnosis): Support Ros function in string property

### DIFF
--- a/src/language-service/model/customTags.ts
+++ b/src/language-service/model/customTags.ts
@@ -1,0 +1,157 @@
+import * as _ from 'lodash';
+
+export type TagKind = 'sequence' | 'scalar' | 'mapping';
+
+export interface CustomTag {
+  tag: string,
+  kind: TagKind,
+  propertyName: string,
+  description?: string,
+}
+
+/* eslint-disable max-len */
+export const CUSTOM_TAGS: CustomTag[] = [
+  {
+    tag: '!Str',
+    kind: 'scalar',
+    propertyName: 'Fn::Str',
+  },
+  {
+    tag: '!Base64Encode',
+    kind: 'scalar',
+    propertyName: 'Fn::Base64Encode',
+  },
+  {
+    tag: '!Base64Decode',
+    kind: 'scalar',
+    propertyName: 'Fn::Base64Decode',
+  },
+  {
+    tag: '!FindInMap',
+    kind: 'sequence',
+    propertyName: 'Fn::FindInMap',
+    description:
+      'The intrinsic function Fn::FindInMap returns the value corresponding to keys in a two-level map that is declared in the Mappings section.',
+  },
+  {
+    tag: '!GetAtt',
+    kind: 'scalar',
+    propertyName: 'Fn::GetAtt',
+    description:
+      'The Fn::GetAtt intrinsic function returns the value of an attribute from a resource in the template.',
+  },
+  {
+    tag: '!Join',
+    kind: 'sequence',
+    propertyName: 'Fn::Join',
+    description:
+      'The intrinsic function Fn::Join appends a set of values into a single value, separated by the specified delimiter.',
+  },
+  {
+    tag: '!Select',
+    kind: 'sequence',
+    propertyName: 'Fn::Select',
+    description:
+      'The intrinsic function Fn::Select returns a single object from a list of objects by index.',
+  },
+  {
+    tag: '!Ref',
+    kind: 'scalar',
+    propertyName: 'Ref',
+    description:
+      'The intrinsic function Ref returns the value of the specified parameter or resource.',
+  },
+  {
+    tag: '!GetAZs',
+    kind: 'scalar',
+    propertyName: 'Fn::GetAZs',
+    description:
+      'The intrinsic function Fn::GetAZs returns an array that lists Availability Zones for a specified region.',
+  },
+  {
+    tag: '!Replace',
+    kind: 'sequence',
+    propertyName: 'Fn::Replace',
+  },
+  {
+    tag: '!Split',
+    kind: 'sequence',
+    propertyName: 'Fn::Split',
+    description:
+      'To split a string into a list of string values so that you can select an element from the resulting string list, use the Fn::Split intrinsic function.',
+  },
+  {
+    tag: '!Equals',
+    kind: 'sequence',
+    propertyName: 'Fn::Equals',
+    description: 'Compares if two values are equal.',
+  },
+  {
+    tag: '!And',
+    kind: 'sequence',
+    propertyName: 'Fn::And',
+    description:
+      'Returns true if all the specified conditions evaluate to true, or returns false if any one of the conditions evaluates to false.',
+  },
+  {
+    tag: '!Or',
+    kind: 'sequence',
+    propertyName: 'Fn::Or',
+    description:
+      'Returns true if any one of the specified conditions evaluate to true, or returns false if all of the conditions evaluates to false.',
+  },
+  {
+    tag: '!Not',
+    kind: 'sequence',
+    propertyName: 'Fn::Not',
+    description:
+      'Returns true for a condition that evaluates to false or returns false for a condition that evaluates to true.',
+  },
+  {
+    tag: '!If',
+    kind: 'sequence',
+    propertyName: 'Fn::If',
+    description:
+      'Returns one value if the specified condition evaluates to true and another value if the specified condition evaluates to false.',
+  },
+  {
+    tag: '!ListMerge',
+    kind: 'sequence',
+    propertyName: 'Fn::ListMerge',
+  },
+  {
+    tag: '!GetJsonValue',
+    kind: 'sequence',
+    propertyName: 'Fn::GetJsonValue',
+  },
+  {
+    tag: '!MergeMapToList',
+    kind: 'sequence',
+    propertyName: 'Fn::MergeMapToList',
+  },
+  {
+    tag: '!Avg',
+    kind: 'sequence',
+    propertyName: 'Fn::Avg',
+  },
+  {
+    tag: '!SelectMapList',
+    kind: 'sequence',
+    propertyName: 'Fn::SelectMapList',
+  },
+  {
+    tag: '!Add',
+    kind: 'sequence',
+    propertyName: 'Fn::Add',
+  },
+  {
+    tag: '!Calculate',
+    kind: 'sequence',
+    propertyName: 'Fn::Calculate',
+  }
+]
+
+export const CUSTOM_TAGS_BY_PROPERTY_NAME: { [key: string]: CustomTag } = _.keyBy(
+  CUSTOM_TAGS,
+  'propertyName',
+);

--- a/src/language-service/schema/funSchema.json
+++ b/src/language-service/schema/funSchema.json
@@ -1005,10 +1005,31 @@
       ]
     },
     "Parameters": {
-      "type": "object"
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z_][a-zA-Z.0-9_-]{0,127}$": {
+          "type": "object",
+          "properties": {
+            "Type": {
+              "type": "string",
+              "enum": [
+                "String",
+                "Number",
+                "CommaDelimitedList",
+                "Json",
+                "Boolean"
+              ]
+            }
+          },
+          "required": ["Type"]
+        }
+      }
     },
     "Outputs": {
       "type": "object"
+    },
+    "Description": {
+      "type": "string"
     },
     "Resources": {
       "type": "object",

--- a/src/parser/ASTNode.ts
+++ b/src/parser/ASTNode.ts
@@ -1,5 +1,6 @@
 import { JSONSchema } from '../language-service/jsonSchema';
 import { ValidationResult, ISchemaCollector, ProblemSeverity } from '../language-service/parser/jsonParser';
+import { CustomTag } from '../language-service/model/customTags';
 
 export class ASTNode {
   start: number;
@@ -7,17 +8,20 @@ export class ASTNode {
   type: string;
   parent: ASTNode | undefined;
   slot: string | undefined;
+  customTag: CustomTag | undefined;
 
   constructor(
     parent: ASTNode | undefined,
     type: string,
     start: number,
-    end: number
+    end: number,
+    customTag?: CustomTag,
   ) {
     this.parent = parent;
     this.type = type;
     this.start = start;
     this.end = end;
+    this.customTag = customTag;
   }
 
   getValue(): any {

--- a/src/parser/ObjectASTNode.ts
+++ b/src/parser/ObjectASTNode.ts
@@ -46,6 +46,13 @@ export class ObjectASTNode extends ASTNode {
     if (!matchingSchemas.include(this)) {
       return;
     }
+    if (
+      schema.type === 'string' &&
+      this.properties.length === 1 &&
+      this.properties[0].customTag
+    ) {
+      return;
+    }
     super.validate(schema, validationResult, matchingSchemas);
     const seenKeys: { [key: string]: ASTNode } = Object.create(null);
     const unprocessedProperties: string[] = [];

--- a/src/parser/PropertyASTNode.ts
+++ b/src/parser/PropertyASTNode.ts
@@ -3,14 +3,21 @@ import { StringASTNode } from './StringASTNode';
 import { SlotASTNode } from './SlotASTNode';
 import { JSONSchema } from '../language-service/jsonSchema';
 import { ValidationResult, ISchemaCollector } from '../language-service/parser/jsonParser';
+import { CustomTag } from '../language-service/model/customTags';
 
 export class PropertyASTNode extends SlotASTNode {
   key: StringASTNode;
   value: ASTNode | undefined;
   colonOffset: number;
 
-  constructor(parent: ASTNode | undefined, key: StringASTNode, start: number, end: number) {
-    super(parent, 'property', start, end);
+  constructor(
+    parent: ASTNode | undefined,
+    key: StringASTNode,
+    start: number,
+    end: number,
+    customTag?: CustomTag,
+  ) {
+    super(parent, 'property', start, end, customTag);
     this.key = key;
     this.key.parent = this;
     this.slot = key.value;

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -7,6 +7,7 @@ import { StringASTNode } from './StringASTNode';
 import { ArrayASTNode } from './ArrayASTNode';
 import { BooleanASTNode } from './BooleanASTNode';
 import { NumberASTNode } from './NumberASTNode';
+import { CUSTOM_TAGS_BY_PROPERTY_NAME } from '../language-service/model/customTags';
 
 export function buildAstRecursively(parent: ASTNode | undefined, node: Yaml.YAMLNode): ASTNode {
   if (!node) {
@@ -38,8 +39,9 @@ export function buildAstRecursively(parent: ASTNode | undefined, node: Yaml.YAML
         key.endPosition,
       );
       keyNode.value = key.value;
+      const customTag = CUSTOM_TAGS_BY_PROPERTY_NAME[key.value];
 
-      const result = new PropertyASTNode(parent, keyNode, keyNode.start, instance.endPosition);
+      const result = new PropertyASTNode(parent, keyNode, keyNode.start, instance.endPosition, customTag);
 
       const valueNode = instance.value
         ? buildAstRecursively(result, instance.value)

--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -421,5 +421,8 @@ const resourceSchema = {
 export const schema = {
   properties: {
     Resources: resourceSchema,
+    Description: {},
+    Parameters: {},
+    Outputs: {},
   },
 };


### PR DESCRIPTION
1. 进一步支持 ROS 模版语法中的 `Parameters`、`Description`、`Outputs`
2. template.yml 中语法校验支持在允许填写 string 类型的属性中使用 ROS 方法，如 Ref、Fn::GetAttr 等

![ros](https://user-images.githubusercontent.com/19430792/71154598-d009a600-2276-11ea-92bd-9851e5d56e6f.gif)

