### PR TITLE
feat(Functionn Flow): 本地资源相关操作支持 FnF

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,6 +223,14 @@
         }
       },
       {
+        "command": "fc.extension.localResource.gotoFlow",
+        "title": "Goto Flow",
+        "icon": {
+          "light": "media/light/code.svg",
+          "dark": "media/dark/code.svg"
+        }
+      },
+      {
         "command": "fc.extension.service.import",
         "title": "Import Service",
         "icon": {
@@ -551,6 +559,16 @@
           "group": "2_local@1"
         },
         {
+          "command": "fc.extension.localResource.gotoFlow",
+          "when": "view == fcLocalResource && viewItem == flow",
+          "group": "inline"
+        },
+        {
+          "command": "fc.extension.localResource.gotoFlow",
+          "when": "view == fcLocalResource && viewItem == flow",
+          "group": "2_local@1"
+        },
+        {
           "command": "fc.extension.remoteResource.remote.invoke",
           "when": "view == fcRemoteResource && viewItem == function",
           "group": "inline"
@@ -623,6 +641,10 @@
         },
         {
           "command": "fc.extension.localResource.gotoFunction",
+          "when": "never"
+        },
+        {
+          "command": "fc.extension.localResource.gotoFlow",
           "when": "never"
         },
         {

--- a/src/commands/gotoFlowCode.ts
+++ b/src/commands/gotoFlowCode.ts
@@ -1,0 +1,44 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { ext } from '../extensionVariables';
+import { serverlessCommands } from '../utils/constants';
+import { isPathExists } from '../utils/file';
+import { recordPageView } from '../utils/visitor';
+import { Resource, ResourceType, FlowResource } from '../models/resource';
+import { TemplateService } from '../services/TemplateService';
+
+export function gotoFlowCode(context: vscode.ExtensionContext) {
+  vscode.commands.registerCommand(serverlessCommands.GOTO_FLOW_CODE.id, async (node: Resource) => {
+    recordPageView('/gotoFlowCode');
+    if (node.resourceType !== ResourceType.Flow) {
+      return;
+    }
+    const flowRes = node as FlowResource;
+    await process(flowRes.flowName, flowRes.templatePath as string);
+  });
+}
+
+export async function process(flowName: string, templatePath: string) {
+  if (!ext.cwd) {
+    vscode.window.showErrorMessage('Please open a workspace');
+    return;
+  }
+
+  const templateService = new TemplateService(templatePath);
+  const flowInfo = await templateService.getFlow(flowName);
+  const { Properties: { DefinitionUri = '' } = {} } = flowInfo;
+  if (!DefinitionUri) {
+    vscode.window.showErrorMessage(`${flowName} does not have DefinitionUri.`);
+    return;
+  }
+  let localRoot = path.resolve(path.dirname(templatePath), DefinitionUri);
+  if (!localRoot || !isPathExists(localRoot)) {
+    vscode.window.showErrorMessage(`${localRoot} did not found`);
+    return;
+  }
+  const document = await vscode.workspace.openTextDocument(vscode.Uri.file(localRoot));
+  await vscode.window.showTextDocument(document, {
+    preserveFocus: true,
+    preview: true,
+  });
+}

--- a/src/commands/gotoFlowDefinition.ts
+++ b/src/commands/gotoFlowDefinition.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+import { ext } from '../extensionVariables';
+import { serverlessCommands } from '../utils/constants';
+import { isPathExists } from '../utils/file';
+import { recordPageView } from '../utils/visitor';
+import { TemplateService } from '../services/TemplateService';
+import { findBlockEndLine, createDecorationTypesByOpacity, decorateEditor } from '../utils/document';
+
+const serviceDecorationTypes: vscode.TextEditorDecorationType[] = createDecorationTypesByOpacity(
+  { r: 255, g: 255, b: 64 },
+  0.3,
+  0.01,
+  0.03,
+);
+
+export function gotoFlowDefinition(context: vscode.ExtensionContext) {
+  context.subscriptions.push(vscode.commands.registerCommand(serverlessCommands.GOTO_FLOW_DEFINITION.id,
+    async (flowName: string, templatePath: string) => {
+      recordPageView('/gotoFlowDefinition');
+      await process(flowName, templatePath);
+    })
+  );
+}
+
+async function process(flowName: string, templatePath: string) {
+  if (!ext.cwd) {
+    vscode.window.showErrorMessage('Please open a workspace');
+    return;
+  }
+
+  if (!isPathExists(templatePath)) {
+    vscode.window.showErrorMessage(`${templatePath} did not found`);
+    return;
+  }
+  const templateService = new TemplateService(templatePath);
+  const templateContent = await templateService.getTemplateContent();
+  if (!templateContent) {
+    vscode.window.showErrorMessage('template.yml is empty or not exist');
+    return;
+  }
+  const templateContentLines = templateContent.split('\n');
+  let lineNumber = 0;
+  let flowFound = false;
+  for (const line of templateContentLines) {
+    if (line.trim().indexOf(flowName + ':') >= 0) {
+      flowFound = true;
+      break;
+    }
+    lineNumber++;
+  }
+  lineNumber = flowFound ? lineNumber : 0;
+  const cursorPosition = new vscode.Position(lineNumber, 0);
+  const document = await vscode.workspace.openTextDocument(vscode.Uri.file(templatePath));
+  await vscode.window.showTextDocument(document, {
+    preserveFocus: true,
+    preview: true,
+  }).then(editor => {
+    editor.selections = [new vscode.Selection(cursorPosition, cursorPosition)];
+    editor.revealRange(new vscode.Range(cursorPosition, new vscode.Position(lineNumber + 10, 0)));
+    if (flowFound) {
+      const endLine = findBlockEndLine(document, cursorPosition);
+      const decorationRange = new vscode.Range(new vscode.Position(lineNumber, 0), new vscode.Position(endLine + 1, 0));
+      editor.setDecorations(serviceDecorationTypes[0], [decorationRange]);
+      decorateEditor(editor, decorationRange, serviceDecorationTypes);
+    }
+  });
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -64,6 +64,8 @@ import { gotoFnFConsole } from './commands/fnf/gotoFnFConsole';
 import { showRemoteFlowInfo, clearRemoteFlowInfo } from './commands/fnf/showRemoteFlowInfo';
 import { showDefinitionGraph } from './commands/fnf/showDefinitionGraph';
 import { ROSTemplateDocumentSymbolProvider } from './documentSymbols/ROSTemplateDocumentSymbolProvider';
+import { gotoFlowDefinition } from './commands/gotoFlowDefinition';
+import { gotoFlowCode } from './commands/gotoFlowCode';
 
 export function activate(context: vscode.ExtensionContext) {
   recordPageView('/');
@@ -143,6 +145,8 @@ export function activate(context: vscode.ExtensionContext) {
   clearRemoteFlowInfo(context);
   showDefinitionGraph(context);
   gotoFCConsole(context);
+  gotoFlowDefinition(context);
+  gotoFlowCode(context);
 
   vscode.commands.executeCommand(serverlessCommands.SHOW_REGION_STATUS.id);
   vscode.commands.executeCommand(serverlessCommands.SHOW_UPDATE_NOTIFICATION.id);

--- a/src/models/resource.ts
+++ b/src/models/resource.ts
@@ -180,17 +180,21 @@ export class TriggerResource extends Resource {
 
 export class FlowResource extends Resource {
   flowName: string;
+  templatePath: string | undefined;
   constructor(
     flowName: string,
     command?: vscode.Command,
+    collapsibleState?: vscode.TreeItemCollapsibleState,
+    templatePath?: string,
   ) {
     super(
       flowName,
       ResourceType.Flow,
-      vscode.TreeItemCollapsibleState.Collapsed,
+      collapsibleState !== undefined ? collapsibleState : vscode.TreeItemCollapsibleState.Collapsed,
       command,
     );
     this.flowName = flowName;
+    this.templatePath = templatePath;
     this.iconPath = {
       light: path.resolve(__dirname, '..', '..', 'media', 'light', 'flow.svg'),
       dark: path.resolve(__dirname, '..', '..', 'media', 'dark', 'flow.svg'),

--- a/src/services/TemplateService.ts
+++ b/src/services/TemplateService.ts
@@ -5,7 +5,7 @@ import * as yaml from 'js-yaml';
 import * as util from 'util';
 import { isJava } from '../utils/runtime';
 import { isDirectory } from '../utils/file';
-import { ALIYUN_SERVERLESS_FUNCTION_TYPE } from '../utils/constants';
+import { ALIYUN_SERVERLESS_FUNCTION_TYPE, ALIYUN_SERVERLESS_FLOW_TYPE } from '../utils/constants';
 import { getSuffix } from '../utils/runtime';
 
 const readFile = util.promisify(fs.readFile);
@@ -114,6 +114,22 @@ export class TemplateService {
       .filter(([name, resource]) => name === serviceName && resource.Type === 'Aliyun::Serverless::Service' );
     if (services.length > 0) {
       return services[0][1];
+    }
+    return null;
+  }
+  async getFlow(flowName: string): Promise<any> {
+    if (!this.templateExists()) {
+      return null;
+    }
+    const content = await readFile(this.getTemplatePath(), 'utf8');
+    const tpl = <Tpl>yaml.safeLoad(content);
+    if (!tpl.Resources) {
+      return null;
+    }
+    const flows = Object.entries(tpl.Resources)
+      .filter(([name, resource]) => name === flowName && resource.Type === ALIYUN_SERVERLESS_FLOW_TYPE );
+    if (flows.length > 0) {
+      return flows[0][1];
     }
     return null;
   }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -39,6 +39,14 @@ export namespace serverlessCommands {
     id: 'fc.extension.localResource.service.gotoDefinition',
     title: 'Goto Service Definition'
   };
+  export const GOTO_FLOW_DEFINITION = {
+    id: 'fc.extension.localResource.flow.gotoDefinition',
+    title: 'Goto Flow Definition'
+  };
+  export const GOTO_FLOW_CODE = {
+    id: 'fc.extension.localResource.gotoFlow',
+    title: 'Goto Flow Code',
+  };
   export const GOTO_TRIGGER_DEFINITION = {
     id: 'fc.extension.localResource.trigger.gotoDefinition',
     title: 'Goto Trigger Definition'
@@ -264,7 +272,6 @@ export const FC_REGIONS = [
 ]
 export const ALIYUN_SERVERLESS_SERVICE_TYPE = 'Aliyun::Serverless::Service';
 export const ALIYUN_SERVERLESS_FUNCTION_TYPE = 'Aliyun::Serverless::Function';
-
 export const ALIYUN_FUNCTION_COMPUTE_CONSOLE_URL = 'https://fc.console.aliyun.com/';
 
 export const ALIYUN_SERVERLESS_CHANGELOG_URL = 'https://github.com/alibaba/serverless-vscode/blob/master/CHANGELOG.md';


### PR DESCRIPTION
1. 本地资源树提供 Flow 资源显示
2. 在本地资源树中左击 Flow 名称可跳转至模版文件 template.yml 中的对应行，该 Flow 描述块的背景会高亮并逐渐退去。
3. 提供跳转到流程定义文件的功能