### PR TITLE
feat(Template): 支持 template.packaged.yml 以及优化模版文件语法提示

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
           "type": "string",
           "description": "External Fun command which will replace the internal Fun"
         },
+        "aliyun.fc.fun.deploy.assumeYes": {
+          "type": "boolean",
+          "description": "Automatic yes to prompts. Assume \"yes\" as answer to all prompts and run non-interactively.",
+          "default": true
+        },
         "aliyun.fc.referenceLib.tip": {
           "type": "boolean",
           "description": "Tips for enable reference lib that are provided by the runtime",

--- a/src/language-service/schema/rosSchema.ts
+++ b/src/language-service/schema/rosSchema.ts
@@ -88,13 +88,18 @@ export const rosSchema = {
               "insertText": VPCCONFIG_INSERT_TEXT,
             },
             "LogConfig": {
-              "type": "object",
-              "properties": {
-                "Project": { "type": "string" },
-                "Logstore": { "type": "string" }
-              },
-              "required": ["Project", "Logstore"],
-              "additionalProperties": false,
+              "oneOf": [
+                { "type": "string" },
+                {
+                  "type": "object",
+                  "properties": {
+                    "Project": { "type": "string" },
+                    "Logstore": { "type": "string" }
+                  },
+                  "required": ["Project", "Logstore"],
+                  "additionalProperties": false,
+                },
+              ],
               "insertText": LOGCONFIG_INSERT_TEXT,
             },
             "NasConfig": {
@@ -371,6 +376,9 @@ export const rosSchema = {
         },
         "FunctionName": {
           "type": "string"
+        },
+        "Qualifier": {
+          "type": "string"
         }
       },
       "additionalProperties": false
@@ -493,6 +501,15 @@ export const rosSchema = {
           "additionalProperties": false
         }
       },
+      "patternProperties": {
+        "^[a-zA-Z][a-zA-Z0-9-]{0,127}$": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Aliyun::Serverless::Log::Logstore"
+            },
+          ]
+        }
+      },
       "required": ["Type"],
       "document": {
         "default": "https://github.com/alibaba/funcraft/blob/master/docs/specs/2018-04-03.md#aliyunserverlesslog",
@@ -500,6 +517,38 @@ export const rosSchema = {
         "zh-TW": "https://github.com/alibaba/funcraft/blob/master/docs/specs/2018-04-03-zh-cn.md#aliyunserverlesslog"
       },
       "insertText": LOG_INSERT_TEXT,
+    },
+    "Aliyun::Serverless::Log::Logstore": {
+      "$id": "Aliyun::Serverless::Log::Logstore",
+      "type": "object",
+      "properties": {
+        "Type": {
+          "type": "string",
+          "enum": [
+            "Aliyun::Serverless::Log::Logstore"
+          ]
+        },
+        "Properties": {
+          "type": "object",
+          "properties": {
+            "TTL": {
+              "type": "integer"
+            },
+            "ShardCount": {
+              "type": "integer"
+            }
+          },
+          "required": ["TTL", "ShardCount"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["Type", "Properties"],
+      "additionalProperties": false,
+      "document": {
+        "default": "https://github.com/alibaba/funcraft/blob/master/docs/specs/2018-04-03.md#aliyunserverlessloglogstore",
+        "zh-CN": "https://github.com/alibaba/funcraft/blob/master/docs/specs/2018-04-03-zh-cn.md#aliyunserverlessloglogstore",
+        "zh-TW": "https://github.com/alibaba/funcraft/blob/master/docs/specs/2018-04-03-zh-cn.md#aliyunserverlessloglogstore"
+      },
     },
     "Aliyun::Serverless::MNSTopic": {
       "$id": "Aliyun::Serverless::MNSTopic",

--- a/src/services/FunService.ts
+++ b/src/services/FunService.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as terminalService from '../utils/terminal';
 import { getFunBin } from '../utils/fun';
 import { isDirectory } from '../utils/file';
+import { serverlessConfigs } from '../utils/constants';
 
 export class FunService {
   constructor (private templatePath: string) {
@@ -24,11 +25,13 @@ export class FunService {
 
   deploy(serviceName?: string, functionName? :string) {
     const terminal = terminalService.getFunctionComputeTerminal(path.dirname(this.templatePath));
+    const assumeYes =
+      <boolean>vscode.workspace.getConfiguration().get(serverlessConfigs.ALIYUN_FC_FUN_DEPLOY_ASSUMEYES) ? '-y' : '';
     getFunBin().then(funBin => {
       const command = functionName ?
-        `${funBin} deploy ${serviceName}/${functionName} -t ${this.templatePath}` :
-        serviceName ? `${funBin} deploy ${serviceName} -t ${this.templatePath}` :
-          `${funBin} deploy -t ${this.templatePath}`;
+        `${funBin} deploy ${serviceName}/${functionName} -t ${this.templatePath} ${assumeYes}` :
+        serviceName ? `${funBin} deploy ${serviceName} -t ${this.templatePath} ${assumeYes}` :
+          `${funBin} deploy -t ${this.templatePath} ${assumeYes}`;
       terminal.sendText(command);
       terminal.show();
     })

--- a/src/tree/LocalResourceProvider.ts
+++ b/src/tree/LocalResourceProvider.ts
@@ -54,7 +54,7 @@ export class LocalResourceProvider implements vscode.TreeDataProvider<Resource> 
     }
 
     if (!element) {
-      const files = await findFile('**/template.{yml,yaml}', {
+      const files = await findFile('**/template.?(packaged.){yml,yaml}', {
         cwd: this.workspaceRoot,
         ignore: [
           'node_modules/**/template.{yml,yaml}',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -241,6 +241,7 @@ export namespace serverlessConfigs {
   export const ALIYUN_FC_REFERERENCE_LIB_TIP = 'aliyun.fc.referenceLib.tip';
   export const ALIYUN_FC_IMPORT_BASE_PATH = 'aliyun.fc.import.base.path';
   export const ALIYUN_FC_CREATEFUNCTION_CODEURI_PREFIX = 'aliyun.fc.createFunction.codeUri.prefix';
+  export const ALIYUN_FC_FUN_DEPLOY_ASSUMEYES = 'aliyun.fc.fun.deploy.assumeYes';
 }
 
 export const SERVERLESS_EXTENTION_DOCUMENTATION_URL =


### PR DESCRIPTION
- 支持通过 `aliyun.fc.fun.deploy.assumeYes` 配置，自定义在插件部署时是否需要人工与 Fun 交互
- 本地资源面板树支持解析 fun package 后生成的 `template.packaged.yml` 文件
- 模版文件语法提示增强
   - 服务配置 `LogConfig` 支持 Auto
   - 自定义域名路由支持配置 `Qualifier`
   - 补充 `Aliyun::Serverless::Log` 下 `Aliyun::Serverless::Log::Logstore` 的配置描述