### PR TITLE
perf(Template): 优化 Cpu 过载的现象

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,16 @@
             "ms": "^2.1.1"
           }
         },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-8.1.0.tgz",
+          "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
         "glob": {
           "version": "7.1.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -284,6 +294,16 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
           "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-8.1.0.tgz",
+          "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
         },
         "mem": {
           "version": "1.1.0",
@@ -533,6 +553,15 @@
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
+    },
+    "@types/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npm.taobao.org/@types/fs-extra/download/@types/fs-extra-8.1.0.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2F%40types%2Ffs-extra%2Fdownload%2F%40types%2Ffs-extra-8.1.0.tgz",
+      "integrity": "sha1-ERSDS1PDkUgGzQOzMEs3s70iGk0=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/glob": {
       "version": "7.1.1",
@@ -954,6 +983,11 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npm.taobao.org/at-least-node/download/at-least-node-1.0.0.tgz",
+      "integrity": "sha1-YCzUtG6EStTv/JKoARo8RuAjjcI="
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -2865,13 +2899,30 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npm.taobao.org/fs-extra/download/fs-extra-9.0.0.tgz",
+      "integrity": "sha1-tq/DEDbiR7JGbcmcKa55fV1FgKM=",
       "requires": {
+        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^1.0.0"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npm.taobao.org/jsonfile/download/jsonfile-6.0.1.tgz",
+          "integrity": "sha1-mJZsuiFDeMjIS4LghZB7QL9hQXk=",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npm.taobao.org/universalify/download/universalify-1.0.0.tgz",
+          "integrity": "sha1-thodoXPoQ1sv48Z9Kbmt+FlL0W0="
+        }
       }
     },
     "fs.realpath": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,17 @@
           "description": "Tips for enable reference lib that are provided by the runtime",
           "default": true
         },
+        "aliyun.fc.single.template.mode": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Whether use single template mode. If this mode is enabled, only template.(yml|yaml) will be detected"
+        },
+        "aliyun.fc.multi.templates.path": {
+          "type": "array",
+          "default": [
+            "template.yml"
+          ]
+        },
         "aliyun.fnf.remoteResource.enable": {
           "type": "boolean",
           "default": true
@@ -691,6 +702,7 @@
     "@types/dockerode": "^2.5.20",
     "@types/dotenv": "^6.1.1",
     "@types/download": "^6.2.4",
+    "@types/fs-extra": "^8.1.0",
     "@types/glob": "^7.1.1",
     "@types/lodash": "^4.14.144",
     "@types/mocha": "^2.2.42",
@@ -720,6 +732,7 @@
     "dockerode": "^3.0.2",
     "dotenv": "^8.1.0",
     "download": "^7.1.0",
+    "fs-extra": "^9.0.0",
     "glob": "^7.1.4",
     "ignore": "^5.1.4",
     "inquirer": "^5.2.0",

--- a/src/completions/ROSTemplateCompletionProvider.ts
+++ b/src/completions/ROSTemplateCompletionProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as Yaml from 'yaml-ast-parser';
 import * as osLocale from 'os-locale';
-import { isSupportedDocument, fixNodeForCompletion, isTemplateYaml } from '../utils/document';
+import { isSupportedROSDocument, fixNodeForCompletion, isTemplateYaml } from '../utils/document';
 import { buildAstRecursively, getNodeFromOffset } from '../parser/parser';
 import { ASTNode } from '../parser/ASTNode';
 import { JSONSchemaService } from '../language-service/services/jsonSchemaService';
@@ -32,7 +32,7 @@ export class ROSTemplateCompletionProvider implements vscode.CompletionItemProvi
     position: vscode.Position,
   ):
     vscode.ProviderResult<vscode.CompletionItem[] | vscode.CompletionList> {
-    if (!isSupportedDocument(document)) {
+    if (!isSupportedROSDocument(document)) {
       if (isTemplateYaml(document) && position.line === 0) {
         return [rosTempCompletionItem];
       }

--- a/src/decorations/RainbowDecorator.ts
+++ b/src/decorations/RainbowDecorator.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode'
-import { createDecorationTypesByColors, isSupportedDocument, isFlowDefinitionDocument } from '../utils/document';
+import { createDecorationTypesByColors, isSupportedROSDocument, isFlowDefinitionDocument } from '../utils/document';
 import { recordPageView } from '../utils/visitor';
 
 const decorationTypes = createDecorationTypesByColors(
@@ -58,7 +58,7 @@ export class RainbowDecorator {
     if (!document) {
       return false;
     }
-    return isSupportedDocument(document) || isFlowDefinitionDocument(document);
+    return isSupportedROSDocument(document) || isFlowDefinitionDocument(document);
   }
 
   private decorateEditor(editor: vscode.TextEditor) {

--- a/src/definitions/ROSTemplateDefinitionProvider.ts
+++ b/src/definitions/ROSTemplateDefinitionProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { isSupportedDocument } from '../utils/document';
+import { isSupportedROSDocument } from '../utils/document';
 import { isPathExists, isDirectory } from '../utils/file';
 import { getHandlerFileName } from '../utils/runtime';
 import { recordPageView } from '../utils/visitor';
@@ -13,7 +13,7 @@ export class ROSTemplateDefinitionProvider implements vscode.DefinitionProvider 
     if (!cwd) {
       return;
     }
-    if (!isSupportedDocument(document)) {
+    if (!isSupportedROSDocument(document)) {
       return;
     }
     recordPageView('/showFuncDefineLink');

--- a/src/diagnostics/ROSTemplateDiagnosticsProvider.ts
+++ b/src/diagnostics/ROSTemplateDiagnosticsProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as Yaml from 'yaml-ast-parser';
 import { ext } from '../extensionVariables';
-import { isSupportedDocument, isPartialTpl } from '../utils/document';
+import { isSupportedROSDocument, isPartialTpl } from '../utils/document';
 import { ASTNode } from '../parser/ASTNode';
 import { buildAstRecursively } from '../parser/parser';
 import { JSONSchemaService } from '../language-service/services/jsonSchemaService';
@@ -35,7 +35,7 @@ export class ROSTemplateDiagnosticsProvider {
     if (!document) {
       return;
     }
-    if (!isSupportedDocument(document) ||
+    if (!isSupportedROSDocument(document) ||
       disableValidationMarker.test(document.lineAt(0).text) ||
       isPartialTpl(document)
     ) {

--- a/src/documentSymbols/ROSTemplateDocumentSymbolProvider.ts
+++ b/src/documentSymbols/ROSTemplateDocumentSymbolProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as Yaml from 'yaml-ast-parser';
-import { isSupportedDocument } from '../utils/document';
+import { isSupportedROSDocument } from '../utils/document';
 import { buildAstRecursively } from '../parser/parser';
 import { recordPageView } from '../utils/visitor';
 import { ASTNode } from '../parser/ASTNode';
@@ -12,7 +12,7 @@ export class ROSTemplateDocumentSymbolProvider implements vscode.DocumentSymbolP
   provideDocumentSymbols(
     document: vscode.TextDocument
   ): vscode.ProviderResult<vscode.SymbolInformation[]> {
-    if (!isSupportedDocument(document)) {
+    if (!isSupportedROSDocument(document)) {
       return [];
     }
     recordPageView('/templateDocumentSymbol');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,7 @@ import { reportIssue } from './commands/reportIssue';
 import { viewQuickStart } from './commands/viewQuickStart';
 import { showUpdateNotification } from './commands/showUpdateNotification';
 import { referRuntimeLib } from './commands/referRuntimeLib';
-import { isTemplateYaml } from './utils/document';
+import { isSupportedROSDocument } from './utils/document';
 import { templateChangeEventEmitter } from './models/events';
 import { ROSTemplateHoverProvider } from './hovers/ROSTemplateHoverProvider';
 import { FlowDefinitionHoverProvider } from './hovers/FlowDefinitionHoverProvider';
@@ -180,7 +180,7 @@ export function activate(context: vscode.ExtensionContext) {
     new FunfileCompletionProvider(),
   );
 
-  const flowDefinitionSelector = { pattern: '**/*.{yml,yaml}' };
+  const flowDefinitionSelector = { pattern: '**/*.flow.{yml,yaml}' };
   vscode.languages.registerCompletionItemProvider(
     flowDefinitionSelector,
     new FlowDefinitionCompletionProvider(),
@@ -193,7 +193,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   vscode.workspace.onDidChangeTextDocument((event) => {
     const document = event.document;
-    if (isTemplateYaml(document) && !document.isDirty) {
+    if (isSupportedROSDocument(document) && !document.isDirty) {
       templateChangeEventEmitter.fire();
     }
   })

--- a/src/hovers/ROSTemplateHoverProvider.ts
+++ b/src/hovers/ROSTemplateHoverProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as Yaml from 'yaml-ast-parser';
 import * as osLocale from 'os-locale';
-import { isSupportedDocument } from '../utils/document';
+import { isSupportedROSDocument } from '../utils/document';
 import { recordPageView } from '../utils/visitor';
 import { ASTNode } from '../parser/ASTNode';
 import { buildAstRecursively, getNodeFromOffset } from '../parser/parser';
@@ -18,7 +18,7 @@ export class ROSTemplateHoverProvider implements vscode.HoverProvider {
     document: vscode.TextDocument,
     position: vscode.Position,
   ): vscode.ProviderResult<vscode.Hover> {
-    if (!isSupportedDocument(document)) {
+    if (!isSupportedROSDocument(document)) {
       return;
     }
     recordPageView('/templateHover');

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -242,6 +242,8 @@ export namespace serverlessConfigs {
   export const ALIYUN_FC_IMPORT_BASE_PATH = 'aliyun.fc.import.base.path';
   export const ALIYUN_FC_CREATEFUNCTION_CODEURI_PREFIX = 'aliyun.fc.createFunction.codeUri.prefix';
   export const ALIYUN_FC_FUN_DEPLOY_ASSUMEYES = 'aliyun.fc.fun.deploy.assumeYes';
+  export const ALIYUN_FC_SINGLE_TEMPLATE_MODE = 'aliyun.fc.single.template.mode';
+  export const ALIYUN_FC_MULTI_TEMPLATES_PATH = 'aliyun.fc.multi.templates.path';
 }
 
 export const SERVERLESS_EXTENTION_DOCUMENTATION_URL =

--- a/src/utils/document.ts
+++ b/src/utils/document.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
+import { serverlessConfigs } from './constants';
 
 const rosRegExp = /"?'?ROSTemplateFormatVersion"?'?:\s*"?'?2015-09-01"?'?/
 const transformRegExp = /"?'?Transform"?'?:\s*"?'?Aliyun::Serverless-2018-04-03"?'?/
@@ -14,6 +16,29 @@ export function isSupportedDocument(document: vscode.TextDocument): boolean {
   if (isTemplateYaml(document)) {
     const textDocument = document.getText();
     return rosRegExp.test(textDocument);
+  }
+  return false;
+}
+
+
+export function isSupportedROSDocument(document: vscode.TextDocument): boolean {
+  if (!isYamlFile(document)) {
+    return false;
+  }
+  const singleMode = <boolean>vscode.workspace.getConfiguration()
+    .get(serverlessConfigs.ALIYUN_FC_SINGLE_TEMPLATE_MODE);
+  const templates = singleMode
+    ? ['template.yml', 'template.yaml']
+    :  <string[]>vscode.workspace.getConfiguration()
+      .get(serverlessConfigs.ALIYUN_FC_MULTI_TEMPLATES_PATH);
+  const files: string[] = [];
+  for (const template of templates) {
+    const fileName = path.isAbsolute(template)
+      ? template
+      : path.resolve(vscode.workspace.rootPath as string, template);
+    if (fileName === document.fileName && rosRegExp.test(document.getText())) {
+      return true;
+    }
   }
   return false;
 }


### PR DESCRIPTION
目前有用户反馈有时候 VSCode 插件的 CPU 占用率较高, 分析后有以下几点原因:
1. 本地资源树加载会找所有的模板文件, 并且在模板文件更新后会重新更新本地资源树, glob 库占用了很多资源. 目前的多模板是检索所有的 template.yml, 这有几点问题: 1. 并不是所有的模板都会被命名为 template.yml 2. 如果有多模板可以让用户自定义配置需要载入的模板路径.
2. 语法提示功能针对的文件较多

解法有:
1. 默认使用单模板文件模式 [template.yml | template.yaml], 若开启多模板文件模式, 可在配置里面填写模板文件的相对/绝对路径. 
2. 语法提示功能只针对符合单模板/多模板模式下的特定文件, 进行提示.