### PR TITLE
fix(commands/createFunction): 创建函数时在第三步之后按ESC取消后报错

### DIFF
--- a/src/commands/createFunction.ts
+++ b/src/commands/createFunction.ts
@@ -163,6 +163,7 @@ async function process(context: vscode.ExtensionContext, serviceName: string, te
     const functionTypes = ['NORMAL', 'HTTP'];
     if (!state || !state.serviceName
       || !state.functionName 
+      || !state.runtime
       || (!isCustomRuntime(state.runtime) && !functionTypes.includes(state.type))
       || !isSupportedRuntime(state.runtime) 
       || (isCustomRuntime(state.runtime) && !isSupportedCustomRuntimeTemplates(state.functionTemplate))) {


### PR DESCRIPTION
解决报错 Cannot read property 'indexOf' of undefined