### PR TITLE
fix: fix deploy error on windows with fun version 3.6.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 1. 修复 macOS Monterey 系统下，vscode 插件不可用问题
+2. 更新 funcraft win exe 的下载地址为 `https://funcraft-release.oss-accelerate.aliyuncs.com/fun/fun-v${FUN_VERSION}-win.exe.zip`
 
 ## 1.27.18 - 2021-09-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1559,6 +1559,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.nlark.com/co/download/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
     "co-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npm.taobao.org/co-defer/download/co-defer-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -742,6 +742,7 @@
     "@types/js-yaml": "^3.12.1",
     "@typescript-eslint/eslint-plugin": "^1.11.0",
     "@typescript-eslint/parser": "^1.11.0",
+    "co": "^4.6.0",
     "cron-parser": "^2.13.0",
     "cronstrue": "^1.83.0",
     "dockerode": "^3.0.2",

--- a/src/utils/fun.ts
+++ b/src/utils/fun.ts
@@ -104,7 +104,7 @@ class WindowsFunExecutorGenerator extends FunExecutorGenerator {
     }
     const funFileName = `fun-v${FUN_VERSION}-win.exe`;
     await new Promise((resolve, reject) => {
-      download(`https://gosspublic.alicdn.com/fun/${funFileName}.zip`)
+      download(`https://funcraft-release.oss-accelerate.aliyuncs.com/fun/${funFileName}.zip`)
         .pipe(unzipper.Parse())
         .on('entry', (entry) => {
           const fileName = entry.path;


### PR DESCRIPTION
update funcraft download url from
https://funcraft-release.oss-accelerate.aliyuncs.com/fun/fun-v${FUN_VERSION}-win.exe.zip  to
https://gosspublic.alicdn.com/fun/fun-v${FUN_VERSION}-win.exe.zip